### PR TITLE
Add 'SetFileFormat' switch and 'AppSettings' XML section

### DIFF
--- a/Install-Office365Suite.ps1
+++ b/Install-Office365Suite.ps1
@@ -15,6 +15,7 @@ param(
   [Parameter(ParameterSetName = 'NoXML')][String]$SourcePath,
   [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$PinItemsToTaskbar = 'TRUE',
   [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI,
+  [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat,
   [String]$OfficeInstallDownloadPath = 'C:\Scripts\Office365Install',
   [Switch]$CleanUpInstallFiles = $False
 )
@@ -51,6 +52,7 @@ if (!($ConfigurationXMLFile)) {
       -EnableUpdate $EnableUpdates `
       -PinItemsToTaskBar $PinItemsToTaskbar `
       -KeepMSI:$KeepMSI `
+      -SetFileFormat:$SetFileFormat `
   
   }
   else {
@@ -66,6 +68,7 @@ if (!($ConfigurationXMLFile)) {
       -EnableUpdate $EnableUpdates `
       -PinItemsToTaskBar $PinItemsToTaskbar `
       -KeepMSI:$KeepMSI `
+      -SetFileFormat:$SetFileFormat `
   
   }
 

--- a/InstallOffice.psm1
+++ b/InstallOffice.psm1
@@ -15,7 +15,8 @@ function Get-XMLFile {
     [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$EnableUpdates = 'TRUE',
     [Parameter(ParameterSetName = 'NoXML')][String]$SourcePath,
     [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$PinItemsToTaskbar = 'TRUE',
-    [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI
+    [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI,
+    [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat
   )
 
   if ($ExcludeApps) {
@@ -42,6 +43,17 @@ function Get-XMLFile {
   }
   else {
     $RemoveMSIString = '<RemoveMSI />'
+  }
+
+  if ($SetFileFormat) {
+    $AppSettingsString = '<AppSettings>
+      <User Key="software\microsoft\office\16.0\excel\options" Name="defaultformat" Value="51" Type="REG_DWORD" App="excel16" Id="L_SaveExcelfilesas" />
+      <User Key="software\microsoft\office\16.0\powerpoint\options" Name="defaultformat" Value="27" Type="REG_DWORD" App="ppt16" Id="L_SavePowerPointfilesas" />
+      <User Key="software\microsoft\office\16.0\word\options" Name="defaultformat" Value="" Type="REG_SZ" App="word16" Id="L_SaveWordfilesas" />
+    </AppSettings>'
+  }
+  else {
+    $AppSettingsString = $Null
   }
 
   if ($Channel) {
@@ -93,6 +105,7 @@ function Get-XMLFile {
     <Property Name="SharedComputerLicensing" Value="$SharedComputerlicensing" />
     <Display Level="$SilentInstallString" AcceptEULA="$AcceptEULA" />
     <Updates Enabled="$EnableUpdates" />
+    $AppSettingsString
     $RemoveMSIString
   </Configuration>
 "@

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Alternatively, you can set many settings from the command line that you'd like t
 -SourcePath | [String] *Specify path*
 -PinItemsToTaskbar  | TRUE, FALSE (Windows 7 / 8 only!)
 -KeepMSI | [Switch]
+-SetFileFormat | [Switch]
 -CleanUpInstallFiles | [Switch]
 
 ## Additional Info


### PR DESCRIPTION
The 'SetFileFormat' switch activates the 'AppSettings' XML section that is populated with the registery keys that defines the default save format for Word, Excel and PowerPoint. This prevents the pop-up with the default save format choice from appearing for the user on first start of Word, Excel and PowerPoint.