### PR TITLE
Add ChangeArch parameter

### DIFF
--- a/Install-Office365Suite.ps1
+++ b/Install-Office365Suite.ps1
@@ -16,6 +16,7 @@ param(
   [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$PinItemsToTaskbar = 'TRUE',
   [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI,
   [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat,
+  [Parameter(ParameterSetName = 'NoXML')][Switch]$ChangeArch,
   [String]$OfficeInstallDownloadPath = 'C:\Scripts\Office365Install',
   [Switch]$CleanUpInstallFiles = $False
 )
@@ -53,6 +54,7 @@ if (!($ConfigurationXMLFile)) {
       -PinItemsToTaskBar $PinItemsToTaskbar `
       -KeepMSI:$KeepMSI `
       -SetFileFormat:$SetFileFormat `
+      -ChangeArch:$ChangeArch `
   
   }
   else {
@@ -69,6 +71,7 @@ if (!($ConfigurationXMLFile)) {
       -PinItemsToTaskBar $PinItemsToTaskbar `
       -KeepMSI:$KeepMSI `
       -SetFileFormat:$SetFileFormat `
+      -ChangeArch:$ChangeArch `
   
   }
 

--- a/InstallOffice.psm1
+++ b/InstallOffice.psm1
@@ -16,7 +16,8 @@ function Get-XMLFile {
     [Parameter(ParameterSetName = 'NoXML')][String]$SourcePath,
     [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$PinItemsToTaskbar = 'TRUE',
     [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI,
-    [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat
+    [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat,
+    [Parameter(ParameterSetName = 'NoXML')][Switch]$ChangeArch
   )
 
   if ($ExcludeApps) {
@@ -36,6 +37,13 @@ function Get-XMLFile {
 
   if ($OfficeArch) {
     $OfficeArchString = "`"$OfficeArch`""
+  }
+
+  if ($ChangeArch) {
+    $MigrateArch = "MigrateArch=`"TRUE`""
+  }
+  else {
+    $MigrateArch = $Null
   }
 
   if ($KeepMSI) {
@@ -93,7 +101,7 @@ function Get-XMLFile {
 
   $OfficeXML = [XML]@"
   <Configuration>
-    <Add OfficeClientEdition=$OfficeArchString $ChannelString $SourcePathString  >
+    <Add OfficeClientEdition=$OfficeArchString $ChannelString $SourcePathString $MigrateArch >
       <Product ID="$OfficeEdition">
         $LanguageString
         $ExcludeAppsString

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Alternatively, you can set many settings from the command line that you'd like t
 -PinItemsToTaskbar  | TRUE, FALSE (Windows 7 / 8 only!)
 -KeepMSI | [Switch]
 -SetFileFormat | [Switch]
+-ChangeArch | [Switch]
 -CleanUpInstallFiles | [Switch]
 
 ## Additional Info


### PR DESCRIPTION
The ChangeArch parameter adds the "MigrateArch" parameter to the ODT XML file. This forces ODT to uninstall the existing installation if it is of conflicting bitness.