### PR TITLE
Add RemoveAllProducts, ForceOpenAppShutdown and ChangeArch parameter

### DIFF
--- a/Install-Office365Suite.ps1
+++ b/Install-Office365Suite.ps1
@@ -15,6 +15,7 @@ param(
   [Parameter(ParameterSetName = 'NoXML')][String]$SourcePath,
   [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$PinItemsToTaskbar = 'TRUE',
   [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI,
+  [Parameter(ParameterSetName = 'NoXML')][Switch]$RemoveAllProducts,
   [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat,
   [String]$OfficeInstallDownloadPath = 'C:\Scripts\Office365Install',
   [Switch]$CleanUpInstallFiles = $False
@@ -52,6 +53,7 @@ if (!($ConfigurationXMLFile)) {
       -EnableUpdate $EnableUpdates `
       -PinItemsToTaskBar $PinItemsToTaskbar `
       -KeepMSI:$KeepMSI `
+      -RemoveAllProducts:$RemoveAllProducts `
       -SetFileFormat:$SetFileFormat `
   
   }
@@ -68,6 +70,7 @@ if (!($ConfigurationXMLFile)) {
       -EnableUpdate $EnableUpdates `
       -PinItemsToTaskBar $PinItemsToTaskbar `
       -KeepMSI:$KeepMSI `
+      -RemoveAllProducts:$RemoveAllProducts `
       -SetFileFormat:$SetFileFormat `
   
   }

--- a/InstallOffice.psm1
+++ b/InstallOffice.psm1
@@ -16,6 +16,7 @@ function Get-XMLFile {
     [Parameter(ParameterSetName = 'NoXML')][String]$SourcePath,
     [Parameter(ParameterSetName = 'NoXML')][ValidateSet('TRUE', 'FALSE')]$PinItemsToTaskbar = 'TRUE',
     [Parameter(ParameterSetName = 'NoXML')][Switch]$KeepMSI,
+    [Parameter(ParameterSetName = 'NoXML')][Switch]$RemoveAllProducts,
     [Parameter(ParameterSetName = 'NoXML')][Switch]$SetFileFormat
   )
 
@@ -43,6 +44,13 @@ function Get-XMLFile {
   }
   else {
     $RemoveMSIString = '<RemoveMSI />'
+  }
+
+  if ($RemoveAllProducts) {
+    $RemoveAllString = "<Remove All=`"TRUE`" />"
+  }
+  else {
+    $RemoveAllString = $Null
   }
 
   if ($SetFileFormat) {
@@ -107,6 +115,7 @@ function Get-XMLFile {
     <Updates Enabled="$EnableUpdates" />
     $AppSettingsString
     $RemoveMSIString
+    $RemoveAllString
   </Configuration>
 "@
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Alternatively, you can set many settings from the command line that you'd like t
 -SourcePath | [String] *Specify path*
 -PinItemsToTaskbar  | TRUE, FALSE (Windows 7 / 8 only!)
 -KeepMSI | [Switch]
+-RemoveAllProducts | [Switch]
 -SetFileFormat | [Switch]
 -CleanUpInstallFiles | [Switch]
 


### PR DESCRIPTION
The RemoveAllProducts parameter adds the "Remove All" parameter to the ODT XML file. This forces ODT to remove all office products that are not specified in the ODT XML file.

The ForceOpenAppShutdown parameter adds the "FORCEAPPSHUTDOWN" parameter to the ODT XML file. This forces ODT to close open office applications before installation. The user will not be informed before the applications are closed.

The ChangeArch parameter adds the "MigrateArch" parameter to the ODT XML file. This forces ODT to uninstall the existing installation if it is of conflicting bitness.